### PR TITLE
Redraw immediately on data change, do not wait for animation frame

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -546,7 +546,7 @@ class ListView extends Backbone.View {
 
   _invalidate(invalidation, callback) {
     this._state.invalidation |= invalidation;
-    this._scheduleRedraw();
+    _.defer(this._redraw.bind(this));
     this.once('didRedraw', callback);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "main": "dist/backbone-virtualized-listview.js",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "files": [
     "dist",
     "docs"


### PR DESCRIPTION
### Problem
After the data is updated, we scheduled a redraw. However, this won't happen until the next animation frame. If the user switch to another browser tab, the redraw would be delayed for unlimited period. This will cause problem if people want to log the rendering performance.

### Fix
Only use animation frame for scrolling scenarios. If there's data change, schedule a redraw on next tick.