### PR TITLE
Consolidate delayed redraw

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -546,7 +546,7 @@ class ListView extends Backbone.View {
 
   _invalidate(invalidation, callback) {
     this._state.invalidation |= invalidation;
-    _.defer(this._redraw.bind(this));
+    this._scheduleRedraw(true);
     this.once('didRedraw', callback);
   }
 
@@ -655,14 +655,23 @@ class ListView extends Backbone.View {
    */
   render(callback = _.noop) {
     let requestId = null;
+    const redraw = () => {
+      if (!this._state.removed) {
+        this._redraw();
+      }
+    };
 
-    this._scheduleRedraw = () => {
-      if (!requestId) {
+    this._scheduleRedraw = (ignoreAnimationFrame = false) => {
+      if (ignoreAnimationFrame) {
+        if (requestId) {
+          window.cancelAnimationFrame(requestId);
+          requestId = null;
+        }
+        _.defer(redraw);
+      } else if (!requestId) {
         requestId = window.requestAnimationFrame(() => {
           requestId = null;
-          if (!this._state.removed) {
-            this._redraw();
-          }
+          redraw();
         });
       }
     };

--- a/js/index.js
+++ b/js/index.js
@@ -654,25 +654,26 @@ class ListView extends Backbone.View {
    * @param {function} [callback] The callback to notify completion.
    */
   render(callback = _.noop) {
-    let requestId = null;
+    let cancel = _.noop;
+
     const redraw = () => {
+      cancel = _.noop;
       if (!this._state.removed) {
         this._redraw();
       }
     };
 
     this._scheduleRedraw = (ignoreAnimationFrame = false) => {
+      cancel();
+
       if (ignoreAnimationFrame) {
-        if (requestId) {
-          window.cancelAnimationFrame(requestId);
-          requestId = null;
-        }
-        _.defer(redraw);
-      } else if (!requestId) {
-        requestId = window.requestAnimationFrame(() => {
-          requestId = null;
-          redraw();
-        });
+        const timeoutId = window.setTimeout(redraw, 0);
+
+        cancel = _.once(() => window.clearTimeout(timeoutId));
+      } else {
+        const requestId = window.requestAnimationFrame(redraw);
+
+        cancel = _.once(() => window.cancelAnimationFrame(requestId));
       }
     };
     // this._hookUpViewport();

--- a/js/index.js
+++ b/js/index.js
@@ -654,26 +654,28 @@ class ListView extends Backbone.View {
    * @param {function} [callback] The callback to notify completion.
    */
   render(callback = _.noop) {
-    let cancel = _.noop;
+    let animationFrameId = null;
+    let timeoutId = null;
 
     const redraw = () => {
-      cancel = _.noop;
+      animationFrameId = null;
+      timeoutId = null;
       if (!this._state.removed) {
         this._redraw();
       }
     };
 
     this._scheduleRedraw = (ignoreAnimationFrame = false) => {
-      cancel();
-
-      if (ignoreAnimationFrame) {
-        const timeoutId = window.setTimeout(redraw, 0);
-
-        cancel = _.once(() => window.clearTimeout(timeoutId));
-      } else {
-        const requestId = window.requestAnimationFrame(redraw);
-
-        cancel = _.once(() => window.cancelAnimationFrame(requestId));
+      if (!timeoutId) {
+        if (ignoreAnimationFrame) {
+          timeoutId = window.setTimeout(redraw, 0);
+          if (animationFrameId) {
+            window.cancelAnimationFrame(animationFrameId);
+            animationFrameId = null;
+          }
+        } else if (!animationFrameId) {
+          animationFrameId = window.requestAnimationFrame(redraw);
+        }
       }
     };
     // this._hookUpViewport();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "main": "dist/backbone-virtualized-listview.js",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "files": [
     "dist",
     "docs"
@@ -39,7 +39,7 @@
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-3": "^6.11.0",
-    "backbone": "^1.3.3",
+    "backbone": "^1.363",
     "bluebird": "^3.4.1",
     "chai": "^3.5.0",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
### Problem
With the last fix of `_invalidate`, we introduced new issues.
* If the `_invalidate` was called multiple times, it would schedule multiple redraw.
* If the `_invalidate` was called before `render`, the redraw would fail.
* If the `_invalidate` was called after `remove`, the redraw would fail.

### Fix
Reuse the `_scheduleRedraw` method to consolidate the redraw. Add an additional parameter to decide whether we should use animation from or simply next tick.